### PR TITLE
UINotificationFeedbackGenerator.FeedbackType enum usage in haptfeedback

### DIFF
--- a/FCM/ToolKit/FeedbackToolKit.swift
+++ b/FCM/ToolKit/FeedbackToolKit.swift
@@ -57,6 +57,8 @@ func showAlert(with message: String) {
 
     // Present the alert
     ShowAlertAdv(alert)
+
+    haptfeedback(.success)
 }
 
 func ShowAlertAdv(_ alert: UIAlertController) {

--- a/FCM/ToolKit/FeedbackToolKit.swift
+++ b/FCM/ToolKit/FeedbackToolKit.swift
@@ -2,21 +2,12 @@ import UIKit
 
 let generator = UINotificationFeedbackGenerator()
 
-//Haptic Feedback
-func haptfeedback(_ type: Int) -> Void {
-    switch(type) {
-        case 1:
-            generator.notificationOccurred(.success)
-            return
-        case 2:
-            generator.notificationOccurred(.error)
-            return
-        default:
-            return
-    }
+// Haptic Feedback with enum for better readability
+func haptfeedback(_ type: UINotificationFeedbackGenerator.FeedbackType) {
+    generator.notificationOccurred(type)
 }
 
-//Alert Feedback
+// Alert Feedback
 func ShowAlert(_ alert: UIAlertController) -> Void {
     DispatchQueue.main.async {
         guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,


### PR DESCRIPTION
Put an example of calling the feedback type such as haptfeedback(.success) using the value of UINotificationFeedbackGenerator.FeedbackType enum type in showAlert(with:) function 
I just wanted to reduce the code 😭😭